### PR TITLE
Add GitHub Actions workflow for building and pushing container images

### DIFF
--- a/.github/workflows/build_containers.yaml
+++ b/.github/workflows/build_containers.yaml
@@ -1,0 +1,82 @@
+name: Build Container
+
+on:
+  repository_dispatch:
+    types:
+      - rebuild
+
+  push:
+
+jobs:
+  build-container:
+    name: Build Container Image
+    environment: prod
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
+    strategy:
+      matrix:
+        variant:
+          - gh_runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-${{ matrix.variant }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Buildah Build
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: Containerfile.${{ matrix.variant }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      - name: Push image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign the images
+        if: github.ref_name == 'main'
+        env:
+          TAGS: ${{ steps.build-image.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          images=""
+          digest=""
+          for tag in ${TAGS}; do
+            if [[ -z "${digest}" ]]
+            then
+              digest=$(cat $(echo ${tag} | tr '/:' '--')_digest.txt)
+            fi
+            images+="${tag}@${digest} "
+          done
+          cosign sign --key env://COSIGN_PRIVATE_KEY --yes ${images}

--- a/Containerfile.gh_runner
+++ b/Containerfile.gh_runner
@@ -1,0 +1,7 @@
+FROM ghcr.io/jasonn3/fedora_base
+
+RUN dnf install -y buildah git jq podman
+
+# Install docker
+RUN curl -L https://get.docker.com/ | sh
+

--- a/Containerfile.gh_runner
+++ b/Containerfile.gh_runner
@@ -5,3 +5,4 @@ RUN dnf install -y buildah git jq podman
 # Install docker
 RUN curl -L https://get.docker.com/ | sh
 
+RUN useradd -m -s /bin/bash runner

--- a/Containerfile.gh_runner
+++ b/Containerfile.gh_runner
@@ -4,5 +4,6 @@ RUN dnf install -y buildah git jq podman
 
 # Install docker
 RUN curl -L https://get.docker.com/ | sh
+RUN ln -s /usr/lib/systemd/system/docker.service /etc/systemd/system/multi-user.target.wants/docker.service
 
 RUN useradd -m -s /bin/bash runner

--- a/Containerfile.gh_runner
+++ b/Containerfile.gh_runner
@@ -1,4 +1,4 @@
-FROM ghcr.io/jasonn3/fedora_base
+FROM ghcr.io/jasonn3/fedora_base:main
 
 RUN dnf install -y buildah git jq podman
 

--- a/Containerfile.gh_runner
+++ b/Containerfile.gh_runner
@@ -1,9 +1,13 @@
 FROM ghcr.io/jasonn3/fedora_base:main
 
+COPY rootfs.gh_runner/ /
+
 RUN dnf install -y buildah git jq podman
 
 # Install docker
-RUN curl -L https://get.docker.com/ | sh
+RUN dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 RUN ln -s /usr/lib/systemd/system/docker.service /etc/systemd/system/multi-user.target.wants/docker.service
 
 RUN useradd -m -s /bin/bash runner
+
+RUN dnf clean all

--- a/rootfs.gh_runner/etc/yum.repos.d/docker.repo
+++ b/rootfs.gh_runner/etc/yum.repos.d/docker.repo
@@ -1,0 +1,62 @@
+[docker-ce-stable]
+name=Docker CE Stable - $basearch
+baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-stable-debuginfo]
+name=Docker CE Stable - Debuginfo $basearch
+baseurl=https://download.docker.com/linux/fedora/$releasever/debug-$basearch/stable
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-stable-source]
+name=Docker CE Stable - Sources
+baseurl=https://download.docker.com/linux/fedora/$releasever/source/stable
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-test]
+name=Docker CE Test - $basearch
+baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/test
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-test-debuginfo]
+name=Docker CE Test - Debuginfo $basearch
+baseurl=https://download.docker.com/linux/fedora/$releasever/debug-$basearch/test
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-test-source]
+name=Docker CE Test - Sources
+baseurl=https://download.docker.com/linux/fedora/$releasever/source/test
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-nightly]
+name=Docker CE Nightly - $basearch
+baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/nightly
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-nightly-debuginfo]
+name=Docker CE Nightly - Debuginfo $basearch
+baseurl=https://download.docker.com/linux/fedora/$releasever/debug-$basearch/nightly
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg
+
+[docker-ce-nightly-source]
+name=Docker CE Nightly - Sources
+baseurl=https://download.docker.com/linux/fedora/$releasever/source/nightly
+enabled=0
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/fedora/gpg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a GitHub Actions workflow for building and pushing container images to the GitHub Container Registry.
  - Added steps for handling metadata, logging in, building, pushing, and signing container images.
  - Configured the workflow to trigger on repository dispatch with the `rebuild` event type and on push events.
  - Utilized GitHub secrets for authentication and image signing.
  - Set up conditional image signing for the `main` branch.

- **New Features**
  - Created a Fedora-based container environment with essential tools like Buildah, Git, jq, Podman, and Docker.
  - Added repository configurations for Docker CE Stable, Test, and Nightly builds on Fedora.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->